### PR TITLE
feat: mejorar la gestión de logs y actualizar comandos en deno.json

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
     "build": "deno run --allow-all --unstable-kv dev.ts build",
     "preview": "deno run --allow-all --unstable-kv main.ts",
     "update": "deno run -A -r https://fresh.deno.dev/update .",
-    "seed": "deno run --allow-read --allow-write --unstable-kv scripts/seed.ts",
+    "seed": "deno run --allow-read --allow-write --allow-env --unstable-kv scripts/seed.ts",
     "cleanup-data": "deno run --allow-read --allow-write --allow-env --unstable-kv scripts/cleanup-test-data.ts",
     "inspect-db": "deno run --allow-read --allow-write --allow-env --unstable-kv scripts/inspect-database.ts",
     "fix-kv": "deno run --allow-read --allow-write --unstable-kv scripts/fix-kv-data.ts",

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -27,16 +27,22 @@ export class Logger {
 
   private constructor() {
     // Configurar nivel de log desde variable de entorno
-    const envLogLevel = Deno.env.get("LOG_LEVEL");
-    if (envLogLevel) {
-      this.logLevel = LogLevel[envLogLevel as keyof typeof LogLevel] ??
-        LogLevel.INFO;
-    }
+    try {
+      const envLogLevel = Deno.env.get("LOG_LEVEL");
+      if (envLogLevel) {
+        this.logLevel = LogLevel[envLogLevel as keyof typeof LogLevel] ??
+          LogLevel.INFO;
+      }
 
-    // Habilitar logging a archivo en producción
-    const envEnableFile = Deno.env.get("LOG_TO_FILE");
-    if (envEnableFile === "true") {
-      this.enableFile = true;
+      // Habilitar logging a archivo en producción
+      const envEnableFile = Deno.env.get("LOG_TO_FILE");
+      if (envEnableFile === "true") {
+        this.enableFile = true;
+      }
+    } catch {
+      // Si no se puede acceder a variables de entorno, usar valores por defecto
+      this.logLevel = LogLevel.INFO;
+      this.enableFile = false;
     }
   }
 

--- a/scripts/cleanup-test-data.ts
+++ b/scripts/cleanup-test-data.ts
@@ -53,7 +53,7 @@ async function checkDatabaseStatus(title: string = "Estado de la base de datos")
     console.log(`   ${prefix.join('_')}: ${count} registros`);
   }
   
-  await kv.close();
+  kv.close();
 }
 
 async function cleanupTestAppointments(options: CleanupOptions): Promise<number> {
@@ -168,7 +168,7 @@ async function cleanupSessions(): Promise<number> {
     deletedCount++;
   }
   
-  await kv.close();
+  kv.close();
   
   console.log(`   🔐 ${deletedCount} sesiones eliminadas`);
   return deletedCount;
@@ -296,10 +296,10 @@ async function main(): Promise<void> {
     
     // Mostrar estado final
     console.log("\n");
-    await checkDatabaseStatus("Estado final de la base de datos");
+    checkDatabaseStatus("Estado final de la base de datos");
     
     // Generar reporte
-    await generateCleanupReport(
+    generateCleanupReport(
       appointmentsDeleted,
       patientsDeleted,
       usersResult,


### PR DESCRIPTION
- Se ha añadido la opción `--allow-env` al comando `seed` en `deno.json`, permitiendo el acceso a variables de entorno durante la ejecución del script de siembra.
- Se ha mejorado la gestión de logs en la clase `Logger`, implementando un manejo de errores al acceder a las variables de entorno, asegurando que se utilicen valores por defecto si no se pueden acceder.
- Se han eliminado las llamadas a `await` en el cierre de conexiones de base de datos en `cleanup-test-data.ts`, optimizando el flujo de ejecución.
- Estos cambios buscan optimizar la configuración del entorno y mejorar la robustez del sistema de logging.